### PR TITLE
Improve recent categories/tags

### DIFF
--- a/packages/core/src/utils/transactions/transaction-utils.ts
+++ b/packages/core/src/utils/transactions/transaction-utils.ts
@@ -203,7 +203,12 @@ export function updateTransaction(
         // Merge new tags with existing tags or remove tags from existing tags if present
         tags = tags
           .filter((tag) => !remove_tags?.find((removeTag) => removeTag.id === tag.id))
-          .concat(add_tags || [])
+          // Add only new tags that don't already exist
+          .concat(
+            (add_tags || []).filter(
+              (addTag) => !tags.some((existingTag) => existingTag.id === addTag.id),
+            ),
+          )
       }
       return {
         ...lineItem,

--- a/packages/frontend/src/components/Table/Table.tsx
+++ b/packages/frontend/src/components/Table/Table.tsx
@@ -272,6 +272,9 @@ export default function Table<T>({
     },
     [onRowContextMenu, enableRowSelection],
   )
+  const handleContextMenuClose = React.useCallback(() => {
+    setContextMenuPos({ top: 0, left: 0 })
+  }, [])
 
   // Keep track of parent row index for zebra striping
   let isStriped = false
@@ -422,7 +425,7 @@ export default function Table<T>({
             <ContextMenuElement
               open={contextMenuPos.top !== 0}
               anchorPosition={contextMenuPos}
-              onClose={() => setContextMenuPos({ top: 0, left: 0 })}
+              onClose={handleContextMenuClose}
               table={table}
             />
           )}

--- a/packages/frontend/src/components/TransactionsTable/TransactionsTable.stories.tsx
+++ b/packages/frontend/src/components/TransactionsTable/TransactionsTable.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { TransactionsTable } from '.'
 
 // Mock Data
-import type { IAccount, ITransaction, ITransactionUpdate } from '@angelfish/core'
+import type { IAccount, ITag, ITransaction, ITransactionUpdate } from '@angelfish/core'
 import {
   getAccountsWithRelations,
   getLongTransactions,
@@ -31,10 +31,20 @@ const meta = {
     onSaveTransactions: (items: ITransactionUpdate[]) => action('onSaveTransactions')(items),
     onImportTransactions: () => action('onImportTransactions')(),
   },
-  render: ({ scrollElement, transactions, onSaveTransactions, onDeleteTransaction, ...args }) => {
+  render: ({
+    scrollElement,
+    transactions,
+    onSaveTransactions,
+    onDeleteTransaction,
+    allTags,
+    ...args
+  }) => {
     const RenderComponent = () => {
       // Keep state of transactions so user can edit transactions while testing story
       const [updatedTransactions, setUpdatedTransactions] = React.useState(transactions)
+      // Keep state of tags as we add tags
+      const [updatedTags, setUpdatedTags] = React.useState(allTags)
+
       const saveTransactions = (items: ITransactionUpdate[]) => {
         onSaveTransactions(items)
         const state = structuredClone(updatedTransactions)
@@ -56,6 +66,26 @@ const meta = {
             state.push(transaction as ITransaction)
           }
           setUpdatedTransactions(state)
+
+          // Update Tags if they have changed
+          if (transaction.line_items) {
+            transaction.line_items.forEach((lineItem) => {
+              if (lineItem.tags) {
+                lineItem.tags.forEach((tag) => {
+                  // If tag does not have an ID, generate one and add to updatedTags
+                  if (!tag.id) {
+                    tag.id = 1000 + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER - 1000)
+                    tag.created_on = new Date()
+                    tag.modified_on = new Date()
+                    tag.name = tag.name?.trim()
+                  }
+                  if (!updatedTags.some((t) => t.id === tag.id)) {
+                    setUpdatedTags((prevTags) => [...prevTags, tag as ITag])
+                  }
+                })
+              }
+            })
+          }
         }
       }
       const deleteTransaction = (id: number) => {
@@ -106,6 +136,7 @@ const meta = {
                 onSaveTransactions={saveTransactions}
                 onDeleteTransaction={deleteTransaction}
                 scrollElement={divScrollElement}
+                allTags={updatedTags}
                 {...args}
               />
             </Box>

--- a/packages/frontend/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/frontend/src/components/TransactionsTable/TransactionsTable.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { CurrencyLabel } from '@/components/CurrencyLabel'
 import type { TableProps } from '@/components/Table'
 import { handleRowContextMenu, handleRowSelection } from '@/components/Table'
-import type { ITransaction, UpdateTransactionProperties } from '@angelfish/core'
+import type { ITag, ITransaction, UpdateTransactionProperties } from '@angelfish/core'
 import { createNewTransaction, duplicateTransaction, updateTransactions } from '@angelfish/core'
 import { ContextMenu } from './components/ContextMenu'
 import { FilterBar } from './components/FilterBar'
@@ -41,6 +41,10 @@ declare module '@tanstack/react-table' {
        * All tags available in database
        */
       allTags: TransactionsTableProps['allTags']
+      /**
+       * Recent tags used in transactions
+       */
+      recentTags: ITag[]
       /**
        * Is the row currently in edit mode
        *
@@ -93,6 +97,30 @@ declare module '@tanstack/react-table' {
        * Callback to start Import Transactions Modal
        */
       onImportTransactions?: TransactionsTableProps['onImportTransactions']
+      /**
+       * Add a new category to recent categories (from search box usage)
+       *
+       * @param category  The category to add to recent list
+       */
+      addRecentCategory: (category: any) => void
+      /**
+       * Move an existing recent category to the top of the list
+       *
+       * @param category  The category to move to top
+       */
+      moveRecentCategoryToTop: (category: any) => void
+      /**
+       * Add new tags to recent tags (from search box usage)
+       *
+       * @param tags  The tags to add to recent list
+       */
+      addRecentTags: (tags: ITag[]) => void
+      /**
+       * Move an existing recent tag to the top of the list
+       *
+       * @param tag  The tag to move to top
+       */
+      moveRecentTagToTop: (tag: ITag) => void
     }
   }
 }
@@ -241,8 +269,9 @@ export default function TransactionsTable({
         transactionsTable: {
           account,
           accountsWithRelations,
-          recentCategories,
+          recentCategories: recentCategoriesState, // Use state-managed recent categories
           allTags,
+          recentTags: recentTagsState, // Use state-managed recent tags,
           isEditMode: (id) => id in editRows,
           toggleEditMode: (id, value) => {
             // Determine if row should be in edit mode

--- a/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
+++ b/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
@@ -68,7 +68,7 @@ export default function TransactionTableContextMenu({
 
   // New tags will receive ID after being saved in database so we need to update the recent tags
   // when allTags changes
-  const allTags = React.useMemo(() => {
+  React.useMemo(() => {
     recentTags.forEach((tag) => {
       if (!tag.id) {
         // If tag does not have ID, match it with allTags name and update it
@@ -298,7 +298,7 @@ export default function TransactionTableContextMenu({
                   fullWidth
                   margin="none"
                   placeholder="Search or create new tags"
-                  tags={allTags}
+                  tags={table.options.meta?.transactionsTable?.allTags ?? []}
                   onChange={(tags) => {
                     // Update the transactions with the selected tags
                     const rows = selectedRows.map((row) => row.original)

--- a/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
+++ b/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
@@ -350,6 +350,7 @@ export default function TransactionTableContextMenu({
     onClose,
     recentCategories,
     recentCategoryMenuItems,
+    recentTags,
     recentTagMenuItems,
   ])
 

--- a/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
+++ b/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
@@ -38,7 +38,6 @@ export default function TransactionTableContextMenu({
   table,
 }: TableContextMenuProps<TransactionRow>) {
   const selectedRows = table.getSelectedRowModel().rows
-  const allRows = table.getRowModel().rows
 
   // Component State
   const [showSubMenu, setShowSubMenu] = React.useState<'categories' | 'tags' | null>(null)
@@ -51,20 +50,20 @@ export default function TransactionTableContextMenu({
 
   // Get all transactions and determine total sum of all transactions
   // and whether any of the transactions are split transactions
-  React.useMemo(() => {
+  React.useEffect(() => {
     const transactions = selectedRows.map((row) => row.original.transaction)
     setTotalSum(transactions.reduce((sum, transaction) => sum + transaction.amount, 0))
     setHasSplitTransactions(hasSplitTransaction(transactions))
   }, [selectedRows])
 
   // Generate recently used categories and tags
-  React.useMemo(() => {
-    const transactionRows = allRows.map((row) => row.original)
-    // Only generate first time when allRows is populated
-    if (recentCategories.length > 0 || recentTags.length > 0) return
+  const accountId = table.options.meta?.transactionsTable?.account?.id
+  React.useEffect(() => {
+    if (!accountId) return
+    const transactionRows = table.getRowModel().rows.map((row) => row.original)
     setRecentCategories(getRecentCategories(transactionRows))
     setRecentTags(getRecentTags(transactionRows))
-  }, [allRows, recentCategories, recentTags])
+  }, [accountId, table])
 
   // New tags will receive ID after being saved in database so we need to update the recent tags
   // when allTags changes

--- a/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
+++ b/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.tsx
@@ -66,6 +66,27 @@ export default function TransactionTableContextMenu({
     setRecentTags(getRecentTags(transactionRows))
   }, [allRows, recentCategories, recentTags])
 
+  // New tags will receive ID after being saved in database so we need to update the recent tags
+  // when allTags changes
+  const allTags = React.useMemo(() => {
+    recentTags.forEach((tag) => {
+      if (!tag.id) {
+        // If tag does not have ID, match it with allTags name and update it
+        const matchedTag = table.options.meta?.transactionsTable?.allTags.find(
+          (t) => t.name === tag.name,
+        )
+        if (matchedTag) {
+          tag.id = matchedTag.id
+          tag.created_on = matchedTag.created_on
+          tag.modified_on = matchedTag.modified_on
+          tag.name = matchedTag.name
+        }
+      }
+    })
+
+    return table.options.meta?.transactionsTable?.allTags ?? []
+  }, [table.options.meta?.transactionsTable?.allTags, recentTags])
+
   // Generate recently used category items
   const recentCategoryMenuItems: ContextMenuItem[] = React.useMemo(() => {
     return recentCategories.map((category) => {
@@ -277,7 +298,7 @@ export default function TransactionTableContextMenu({
                   fullWidth
                   margin="none"
                   placeholder="Search or create new tags"
-                  tags={table.options.meta?.transactionsTable?.allTags ?? []}
+                  tags={allTags}
                   onChange={(tags) => {
                     // Update the transactions with the selected tags
                     const rows = selectedRows.map((row) => row.original)

--- a/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.utils.tsx
+++ b/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.utils.tsx
@@ -15,10 +15,10 @@ export function getRecentCategories(transactionRows: TransactionRow[], limit = 5
   // Step 1: Sort transactions by modified_on descending, fallback to transaction.id
   const sortedTransactions = transactionRows.slice().sort((a, b) => {
     return DateSort(
-      a.transaction.modified_on,
-      a.transaction.id,
       b.transaction.modified_on,
       b.transaction.id,
+      a.transaction.modified_on,
+      a.transaction.id,
     )
   })
 
@@ -75,10 +75,10 @@ export function getRecentTags(transactionRows: TransactionRow[], limit = 5): ITa
   // Step 1: Sort transactions by modified_on descending, fallback to transaction.id
   const sortedTransactions = transactionRows.slice().sort((a, b) => {
     return DateSort(
-      a.transaction.modified_on,
-      a.transaction.id,
       b.transaction.modified_on,
       b.transaction.id,
+      a.transaction.modified_on,
+      a.transaction.id,
     )
   })
 

--- a/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.utils.tsx
+++ b/packages/frontend/src/components/TransactionsTable/components/ContextMenu/ContextMenu.utils.tsx
@@ -1,0 +1,126 @@
+import type { IAccount, ITag } from '@angelfish/core'
+import type { TransactionRow } from '../../data'
+import { DateSort } from '../../data'
+
+/**
+ * Process rows to get array of recently used categories. Will return last N Categories
+ * depending on limit. Used to get initial categories for context menu.
+ *
+ * @param transactionRows   Sorted array of Transaction Rows from buildTransactionRows function
+ * @param limit             Max number of categories to return (@default 5)
+ */
+export function getRecentCategories(transactionRows: TransactionRow[], limit = 5): IAccount[] {
+  const recentCategories: IAccount[] = []
+
+  // Step 1: Sort transactions by modified_on descending, fallback to transaction.id
+  const sortedTransactions = transactionRows.slice().sort((a, b) => {
+    return DateSort(
+      a.transaction.modified_on,
+      a.transaction.id,
+      b.transaction.modified_on,
+      b.transaction.id,
+    )
+  })
+
+  // Step 2: Collect distinct categories in order of most recent usage
+  for (const row of sortedTransactions) {
+    if (!row.isSplit && row.category) {
+      const alreadyIncluded = recentCategories.some((cat) => cat.id === row.category?.id)
+      if (!alreadyIncluded) {
+        recentCategories.push(row.category)
+      }
+      if (recentCategories.length >= limit) {
+        break
+      }
+    }
+  }
+
+  return recentCategories
+}
+
+/**
+ * Update the recent categories list by moving the specified category to the top.
+ *
+ * @param recentCategories  Array of recently used categories
+ * @param category          The category to move to the top
+ * @param limit             Maximum number of categories to keep in the list
+ * @returns                 Updated array of recently used categories
+ */
+export function updateRecentCategories(
+  recentCategories: IAccount[],
+  category: IAccount,
+  limit = 5,
+): IAccount[] {
+  // Move this category to the top of recent categories if it exists
+  const index = recentCategories.findIndex((cat) => cat.id === category.id)
+  if (index > -1) {
+    recentCategories.splice(index, 1)
+  }
+  recentCategories.unshift(category)
+
+  // Limit to max length
+  return recentCategories.slice(0, limit)
+}
+
+/**
+ * Process rows to get array of recently used tags. Will return last N Tags
+ * depending on limit. Used to get initial tags for context menu.
+ *
+ * @param transactionRows   Sorted array of Transaction Rows from buildTransactionRows function
+ * @param limit             Max number of tags to return (@default 5)
+ */
+export function getRecentTags(transactionRows: TransactionRow[], limit = 5): ITag[] {
+  const recentTags: ITag[] = []
+
+  // Step 1: Sort transactions by modified_on descending, fallback to transaction.id
+  const sortedTransactions = transactionRows.slice().sort((a, b) => {
+    return DateSort(
+      a.transaction.modified_on,
+      a.transaction.id,
+      b.transaction.modified_on,
+      b.transaction.id,
+    )
+  })
+
+  // Step 2: Collect distinct tags in order of most recent usage
+  for (const row of sortedTransactions) {
+    if (row.tags && row.tags.length > 0) {
+      for (const tag of row.tags) {
+        const alreadyIncluded = recentTags.some((t) => t.id === tag.id)
+        if (!alreadyIncluded) {
+          recentTags.push(tag)
+        }
+        if (recentTags.length >= limit) {
+          break
+        }
+      }
+    }
+    if (recentTags.length >= limit) {
+      break
+    }
+  }
+
+  return recentTags
+}
+
+/**
+ * Update the recent tags list by moving the specified tags to the top.
+ *
+ * @param recentTags  Array of recently used tags
+ * @param tags        The tags to move to the top
+ * @param limit       Maximum number of tags to keep in the list
+ * @returns           Updated array of recently used tags
+ */
+export function updateRecentTags(recentTags: ITag[], tags: ITag[], limit = 5): ITag[] {
+  for (const tag of tags) {
+    // Move this tag to the top of recent tags if it exists
+    const index = recentTags.findIndex((t) => t.id === tag.id)
+    if (index > -1) {
+      recentTags.splice(index, 1)
+    }
+    recentTags.unshift(tag)
+  }
+
+  // Limit to max length
+  return recentTags.slice(0, limit)
+}

--- a/packages/frontend/src/components/TransactionsTable/data/utils.ts
+++ b/packages/frontend/src/components/TransactionsTable/data/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Helper Functions to process data for the Transactions Table
  */
-import type { IAccount, ILineItemUpdate, ITag, ITransaction } from '@angelfish/core'
+import type { IAccount, ILineItemUpdate, ITransaction } from '@angelfish/core'
 import { isSplitTransaction, roundNumber } from '@angelfish/core'
 import { DateSort } from './sorting'
 import type { FormData, TransactionRow } from './types'
@@ -98,75 +98,6 @@ export function buildTransactionRow(
   })
 
   return { ...transactionrow, rows: subRows }
-}
-
-/**
- * Process rows to get array of recently used categories. Will return last N Categories
- * depending on limit
- *
- * @param transactionRows   Sorted array of Transaction Rows from buildTransactionRows function
- * @param limit             Max number of categories to return (@default 5)
- */
-export function getRecentCategories(transactionRows: TransactionRow[], limit = 5): IAccount[] {
-  const recentCategories: IAccount[] = []
-
-  // Step 1: Sort transactions by modified_on descending, fallback to transaction.id
-  const sortedTransactions = [...transactionRows].sort((rowA, rowB) => {
-    const timeDiff = rowB.transaction.modified_on.getTime() - rowA.transaction.modified_on.getTime()
-    return timeDiff !== 0 ? timeDiff : rowB.transaction.id - rowA.transaction.id
-  })
-
-  // Step 2: Collect distinct categories in order of most recent usage
-  for (const row of sortedTransactions) {
-    if (!row.isSplit && row.category) {
-      const alreadyIncluded = recentCategories.some((cat) => cat.id === row.category?.id)
-      if (!alreadyIncluded) {
-        recentCategories.push(row.category)
-      }
-      if (recentCategories.length >= limit) {
-        break
-      }
-    }
-  }
-
-  return recentCategories
-}
-
-/**
- * Process rows to get array of recently used tags. Will return last N Tags
- * depending on limit
- *
- * @param transactionRows   Sorted array of Transaction Rows from buildTransactionRows function
- * @param limit             Max number of tags to return (@default 5)
- */
-export function getRecentTags(transactionRows: TransactionRow[], limit = 5): ITag[] {
-  const recentTags: ITag[] = []
-
-  // Step 1: Sort transactions by modified_on descending, fallback to transaction.id
-  const sortedTransactions = [...transactionRows].sort((rowA, rowB) => {
-    const timeDiff = rowB.transaction.modified_on.getTime() - rowA.transaction.modified_on.getTime()
-    return timeDiff !== 0 ? timeDiff : rowB.transaction.id - rowA.transaction.id
-  })
-
-  // Step 2: Collect distinct tags in order of most recent usage
-  for (const row of sortedTransactions) {
-    if (row.tags && row.tags.length > 0) {
-      for (const tag of row.tags) {
-        const alreadyIncluded = recentTags.some((t) => t.id === tag.id)
-        if (!alreadyIncluded) {
-          recentTags.push(tag)
-        }
-        if (recentTags.length >= limit) {
-          break
-        }
-      }
-    }
-    if (recentTags.length >= limit) {
-      break
-    }
-  }
-
-  return recentTags
 }
 
 /**

--- a/packages/frontend/src/components/forms/TagsField/TagsField.interface.ts
+++ b/packages/frontend/src/components/forms/TagsField/TagsField.interface.ts
@@ -15,11 +15,11 @@ export interface TagsFieldProps extends FormFieldProps {
    */
   onChange: (tags: ITagUpdate[]) => void
   /**
-   * Optionally set the current value for Field
-   */
-  value?: ITag[] | null
-  /**
    *  placeholder for the Field
    */
   placeholder?: string
+  /**
+   * Optionally set the current value for Field
+   */
+  value?: ITag[] | null
 }

--- a/packages/frontend/src/components/forms/TagsField/TagsField.interface.ts
+++ b/packages/frontend/src/components/forms/TagsField/TagsField.interface.ts
@@ -18,4 +18,8 @@ export interface TagsFieldProps extends FormFieldProps {
    * Optionally set the current value for Field
    */
   value?: ITag[] | null
+  /**
+   *  placeholder for the Field
+   */
+  placeholder?: string
 }

--- a/packages/frontend/src/components/forms/TagsField/TagsField.tsx
+++ b/packages/frontend/src/components/forms/TagsField/TagsField.tsx
@@ -10,7 +10,7 @@ import type { TagsFieldProps } from './TagsField.interface'
  */
 
 export default React.forwardRef<HTMLDivElement, TagsFieldProps>(function TagsField(
-  { tags, onChange, value, id = 'tag-field', ...formFieldProps }: TagsFieldProps,
+  { tags, placeholder, onChange, value, id = 'tag-field', ...formFieldProps }: TagsFieldProps,
   ref,
 ) {
   /**
@@ -24,6 +24,7 @@ export default React.forwardRef<HTMLDivElement, TagsFieldProps>(function TagsFie
     <AutocompleteField
       id={id}
       formRef={ref}
+      placeholder={placeholder}
       {...formFieldProps}
       multiple
       freeSolo


### PR DESCRIPTION
This PR improves the recent categories and adds recent tags to the context menu. Instead of calculating the recent categories whenever the table data changes, it uses the table data to get the most recently modified transactions categories/tags and then updates the recent lists in place as the user makes changes using the context menu, so the most recently used category/tag applied to transactions will always be at the top of the recent list. 

Using modified date isn't reliable other than for populating the first time to get some recent categories/tags, as editing anything on the transaction will change the modified date, not just changing category/tags, so this new approach ensures that the most recent category/tag used via the context menu is always at the top of the list even if the user edits another transaction that doesn't change the recent category/tags.

This approach isn't perfect (i.e. what if user updates a transaction's tags/category outside of the context menu?) but should be good enough for the general use case of quickly multi-selecting transactions and categorising them via the context menu or adding tags for bulk updates.